### PR TITLE
Fix problem communicating with DreamHost

### DIFF
--- a/Library/UpdateJob.cs
+++ b/Library/UpdateJob.cs
@@ -140,6 +140,8 @@ namespace DHDns.Library
         {
             try
             {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+                
                 var request = WebRequest.CreateHttp(String.Format("{0}?key={1}&unique_id={2}&format=XML&cmd={3}",
                     config.APIUrl,
                     config.APIKey,


### PR DESCRIPTION
According to my logs, something between 4-20-18 and 4-24-18 changed on Dreamhost's API.

This caused the error message "failed to parse DNS records from DreamHost" which was hiding the root cause "Authentication failed because the remote party has closed the transport stream exception".

See: https://stackoverflow.com/questions/35621686/authentication-failed-because-the-remote-party-has-closed-the-transport-stream-e