### PR TITLE
Force TLS 1.2 for communication with DH Api

### DIFF
--- a/Service/Program.cs
+++ b/Service/Program.cs
@@ -3,6 +3,7 @@ using NLog;
 using NLog.Config;
 using Quartz;
 using Quartz.Impl;
+using System.Net;
 using Topshelf;
 
 namespace DHDns.Service
@@ -11,6 +12,9 @@ namespace DHDns.Service
     {
         private static void Main(string[] args)
         {
+            // Force TLS 1.2
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             HostFactory.Run(x =>
             {
                 x.Service<TaskService>();


### PR DESCRIPTION
This service broke once DH started enforcing TLS 1.2 on their api. This updates the service to use TLS 1.2 by default.